### PR TITLE
Fixed typo in descriptive text

### DIFF
--- a/src/main/java/net/darkhax/caliper/profiling/profilers/events/EventInfo.java
+++ b/src/main/java/net/darkhax/caliper/profiling/profilers/events/EventInfo.java
@@ -79,7 +79,7 @@ public class EventInfo {
         table.addColumn("Location", info -> info.location);
         table.addColumn("Priority", info -> info.priority);
         table.addColumn("Source", info -> info.source);
-        table.addColumn("RecieveCandeled", info -> info.recievedCanceled);
+        table.addColumn("RecieveCanceled", info -> info.recievedCanceled);
         return table;
     }
 


### PR DESCRIPTION
While forking to submit a PR just to fix a single letter typo in a descriptive text may seem a bit excessive, I'm imagining that it's actually much easier for everyone involved to do it this way than to point it out in an issue. 
Either way, no more typo :-)





